### PR TITLE
add MCP server badge

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 David Montgomery
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ For support, feature requests, or to report bugs, please open an issue on the Gi
 ## License
 This project is licensed under the MIT License - see the LICENSE file for details.
 
-This README aims to provide clear instructions on the setup, usage, and customization of the meta-server, as well as important notes on security and support.
+

--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ This server does not implement advanced security measures and is intended for de
 For support, feature requests, or to report bugs, please open an issue on the GitHub repository page.
 
 ## License
-This project is licensed under the MIT License - see the LICENSE file for details.
+MIT License
+
+Copyright (c) 2024 David Montgomery
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Meta MCP Server
 
-The Meta MCP Server is a Model Context Protocol (MCP) based server designed to dynamically generate and manage MCP servers as per user specifications. This meta-server enables the creation of MCP server files and directories through automated processes, making it ideal for rapid development and testing environments.
+"Meta" because it's an MCP Server that Creates MCP Servers. And also because "suck it, Zuck, I got it first"
 
 ## Features
 
@@ -10,52 +10,17 @@ The Meta MCP Server is a Model Context Protocol (MCP) based server designed to d
 - **Error Handling**: Robust error management to ensure stability even when facing invalid inputs or system errors.
 - **Debugging Support**: Detailed logging and system prompts to aid in debugging and operational transparency.
 
-## Requirements
-
-- Node.js (version 12.x or later)
-- NPM (Node Package Manager)
-- Access to a command-line interface (CLI) or terminal
-- Basic understanding of JavaScript and server management
-
-## Installation
-
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/modelcontextprotocol/meta-mcp-server.git```
-Navigate to the server directory:
-```bash
-cd meta-mcp-server
-```
-Install the required NPM packages:
-```bash
-npm install
-```
-
-## Usage
-
-To start the server, run the following command in your terminal:
-```bash
-node index.js
-```
-This will initialize the meta-server, which will be ready to accept instructions for creating new MCP servers based on input parameters.
 
 ### Configure in Claude Desktop
 
-```
-{
-  "outputDir": "path/to/output/directory",
-  "files": [
-    {
-      "path": "relative/path/to/file.js",
-      "content": "file content as a string"
+``` 
+  },
+    "meta-mcp-server": {
+      "command": "npx",
+      "args": ["-y", "meta-mcp-server"]
     }
-  ]
-}
+  }
 ```
-This JSON can be sent via a suitable MCP client that communicates with the meta-server through the MCP protocol.
-
-Configuration
-All configuration details, including paths and server settings, are managed within the config.json file. Modify this file to suit your environment and security requirements.
 
 Security
 This server does not implement advanced security measures and is intended for development purposes only. Ensure that it is operated in a secure environment, and consider implementing additional authentication and validation mechanisms for production use.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Meta MCP Server
 
-"Meta" because it's an MCP Server that Creates MCP Servers. And also because "suck it, Zuck, I got it first"
+"Meta" because it's an MCP Server that Creates MCP Servers. And also because "suck it, Zuck, I got it first" (seriously though I made that connection after the fact).
 
-## Features
+## Features 
+
+AI (poorly) Created Content:
 
 - **Dynamic Server Generation**: Allows for the creation of customized MCP servers by specifying directories and files to be created.
 - **Automated File Management**: Handles the creation of necessary directories and files for new servers automatically.


### PR DESCRIPTION
This PR adds a badge for the [Meta MCP Server](https://glama.ai/mcp/servers/9ve9ntl1n3) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/9ve9ntl1n3">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/9ve9ntl1n3/badge" alt="Meta Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.